### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @carsmie
+/.security/ @carsmie

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: Norgeskart
 repo_types: [Deprecated]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,29 +9,3 @@ spec:
   lifecycle: "deprecated"
   owner: "team_norgeskart_og_topo"
   system: "norgeskart"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_ol-react-kart"
-  title: "Security Champion ol-react-kart"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "carsmie"
-  children:
-  - "resource:ol-react-kart"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "ol-react-kart"
-  links:
-  - url: "https://github.com/kartverket/ol-react-kart"
-    title: "ol-react-kart på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_ol-react-kart"
-  dependencyOf:
-  - "component:ol-react-kart"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml